### PR TITLE
Update repl link to fix error

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A fast and fun form library focused on ease of use, rather than flexibility.
 
 ## Demo
 
-https://svelte.dev/repl/a868a8e86b6f4891a6305d6d0e024b36?version=3.44.2
+https://svelte.dev/repl/a868a8e86b6f4891a6305d6d0e024b36?version=3.46.5
 
 `npm install @leveluptuts/auto-form`
 


### PR DESCRIPTION
I noticed that the REPL link in the `README` broke with the following error: `Unexpected character '@' (MultiSelect.svelte:318:9)`.

But changing the version number to the latest REPL version fixed the issue and the form shows in the output.